### PR TITLE
fix(app): Sentry fixes

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <application>
         <activity android:name="com.cueaudio.live.CUEActivity"
             android:theme="@style/CUEAppTheme" />
+        <meta-data
+            android:name="io.sentry.dsn"
+            android:value="" />
     </application>
 
 </manifest>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.aloompa.cue_light_show.flutter_cue_light_show_sdk_example"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
sentry.io dependency recently added to implementation 'com.cueaudio:cuelive:3.+' which requires setup in AndroidManifest.xml

Add blank ("") sentry.io settings to AndroidManifest.xml to disable sentry.io implementation on Dragonfly app.

Update compile & target min sdk versions to work with Cue Audio updates.