### PR TITLE
fix: Android SDK Version bump

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.aloompa.cue_light_show.flutter_cue_light_show_sdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         jcenter()
@@ -38,7 +38,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -53,3 +53,4 @@ dependencies {
 
     implementation 'com.cueaudio:cuelive:3.+'
 }
+


### PR DESCRIPTION
Bumping the Android SDK Version to resolve a compile time error below when running flutter build apk.



`> A failure occurred while executing com.[REDACTED].build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:3:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_1000 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:4:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_900 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:5:5-93: AAPT: error: resource [REDACTED]:color/system_neutral1_0 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:6:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_800 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:7:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_700 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:8:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_600 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:9:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_500 not found.
     ERROR:/Users/vagrant/.gradle/caches/transforms-3/183421390c1346bbbd3af81920fc3e88/transformed/material-1.6.0/res/values-v31/values-v31.xml:10:5-94: AAPT: error: resource [REDACTED]:color/system_neutral1_400 not found.
    `